### PR TITLE
fix busy loop, early thread termination (and file output)

### DIFF
--- a/AuditLogCollector.py
+++ b/AuditLogCollector.py
@@ -116,6 +116,9 @@ class AuditLogCollector(ApiConnection.ApiConnection):
                 threads.append(threading.Thread(target=self.retrieve_content, daemon=True,
                                                 kwargs={'content_json': blob_json}))
                 threads[-1].start()
+
+        for t in threads:
+            t.join()
         self._graylog_interface.stop()
 
     def retrieve_content(self, content_json, send_to_graylog=True, save_as_file=False):
@@ -253,5 +256,3 @@ if __name__ == "__main__":
                                   graylog_port=argsdict['graylog_port'], graylog_output=argsdict['graylog'],
                                   file_output=argsdict['file'], publisher_id=argsdict['publisher_id'])
     collector.run_once()
-
-


### PR DESCRIPTION
This patchset fixes:
- busy loop problem in case of connection error.
- worker threads could terminate early, interrupting message fetch.
- fixing output to file

In case of connection problem, the collector threads might crash (for example when wrong credentials provided). As a result, the processor thread waits for content_types to become empty (which will never
happen). In the current implementation, the wait is implemented as a busy loop.

This patch introduces a semaphor, so that the collector threads could signal that they finished with their job. This also avoids busy wait (which fixes the request in https://github.com/ddbnl/office365-audit-log-collector/issues/5#issuecomment-475532429).

Program exit did not wait the termination of the collector threads. That could result in not fetching all available logs in one iteration. Added thread joins to fix this.

I added another patch for fixing the file output error too. I needed that so that I could test the changeset. With this patch provided, this PR overlaps a little with https://github.com/ddbnl/office365-audit-log-collector/pull/8 (CC: @kalimer0x00). The difference to #8 is that I used the guards from self, instead of passing as parameter. I also added guards to the interface start/stop parts, as it is not necessary to start those if otherwise one does not use graylog.
It is fine for me if @ddbnl just cherry pick the busy loop and the thread join part, and pick the file output solution from #8, if you prefer that version, as long as these problems are resolved in upstream.

