### PR TITLE
Fix resume

### DIFF
--- a/Source/AuditLogCollector.py
+++ b/Source/AuditLogCollector.py
@@ -407,6 +407,7 @@ class AuditLogCollector(ApiConnection.ApiConnection):
         Retrieve available content blobs for a content type. If the response contains a
         'NextPageUri' there is more content to be retrieved; rerun until all has been retrieved.
         """
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         try:
             logging.log(level=logging.DEBUG, msg='Getting available content for type: "{}"'.format(content_type))
             current_time = datetime.datetime.now(datetime.timezone.utc)

--- a/Source/AuditLogCollector.py
+++ b/Source/AuditLogCollector.py
@@ -429,7 +429,7 @@ class AuditLogCollector(ApiConnection.ApiConnection):
             self.content_types.remove(content_type)
         else:
             self.content_types.remove(content_type)
-            self._last_run_times[content_type] = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+            self._last_run_times[content_type] = current_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def _start_interfaces(self):
 


### PR DESCRIPTION
Use the correct time when persisting the time of the last request.  Previously start_time was used which will always pull from the old time.  If there are no errors we want to use the current run time not the original start time (provided or persisted to disk)