### PR TITLE
Add Dockerfile and Registry Pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    tags:
+     - '**'
+
+jobs:
+  # As the pgvecto-rs module is needed in the Immich Postgres, a custom Bitnami Image Build is implemented.
+  build-postgres:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v2
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and Push Versioned Docker Image
+        id: build-and-push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{  github.ref_name }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -15,5 +15,5 @@ if [[ ! -f /app/config.yaml ]]; then
   echo "No Config File found. Please Mount under /app/config.yaml. Examples: https://github.com/ddbnl/office365-audit-log-collector/tree/master/ConfigExamples"
   exit 1
 fi
-
+cd /app
 ./OfficeAuditLogCollector ${TENANT_ID} ${CLIENT_KEY} ${SECRET_KEY} --config /app/config.yaml

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 if [[ -z "${TENANT_ID}" ]]; then
   echo "The Tendant ID is undefined, please specify using the Environment Variable TENANT_ID"
   exit 1

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -15,5 +15,4 @@ if [[ ! -f /app/config.yaml ]]; then
   echo "No Config File found. Please Mount under /app/config.yaml. Examples: https://github.com/ddbnl/office365-audit-log-collector/tree/master/ConfigExamples"
   exit 1
 fi
-cd /app
-./OfficeAuditLogCollector ${TENANT_ID} ${CLIENT_KEY} ${SECRET_KEY} --config /app/config.yaml
+/OfficeAuditLogCollector ${TENANT_ID} ${CLIENT_KEY} ${SECRET_KEY} --config /app/config.yaml

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -1,0 +1,18 @@
+if [[ -z "${TENANT_ID}" ]]; then
+  echo "The Tendant ID is undefined, please specify using the Environment Variable TENANT_ID"
+  exit 1
+fi
+if [[ -z "${CLIENT_KEY}" ]]; then
+  echo "The Client Key is undefined, please specify using the Environment Variable CLIENT_KEY"
+  exit 1
+fi
+if [[ -z "${SECRET_KEY}" ]]; then
+  echo "The Secret Key is undefined, please specify using the Environment Variable SECRET_KEY"
+  exit 1
+fi
+if [[ ! -f /app/config.yaml ]]; then
+  echo "No Config File found. Please Mount under /app/config.yaml. Examples: https://github.com/ddbnl/office365-audit-log-collector/tree/master/ConfigExamples"
+  exit 1
+fi
+
+./OfficeAuditLogCollector ${TENANT_ID} ${CLIENT_KEY} ${SECRET_KEY} --config /app/config.yaml

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -15,4 +15,5 @@ if [[ ! -f /app/config.yaml ]]; then
   echo "No Config File found. Please Mount under /app/config.yaml. Examples: https://github.com/ddbnl/office365-audit-log-collector/tree/master/ConfigExamples"
   exit 1
 fi
-/OfficeAuditLogCollector ${TENANT_ID} ${CLIENT_KEY} ${SECRET_KEY} --config /app/config.yaml
+cd /app
+/usr/local/bin/OfficeAuditLogCollector "${TENANT_ID}" "${CLIENT_KEY}" "${SECRET_KEY}" --config /app/config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN \
   chmod +x OfficeAuditLogCollector && \
   chmod +x entrypoint.sh
 
-ENTRYPOINT ["bash", "-c", "/app/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM debian:stable-slim
 COPY Docker/entrypoint.sh /
 WORKDIR /app
 COPY Linux/* .
+RUN apt-get update && apt-get install ca-certificates -y
 RUN \
-  mv *OfficeAuditLogCollector* /OfficeAuditLogCollector && \
-  chmod +x /OfficeAuditLogCollector && \
-  chmod +x /entrypoint.sh
-
+  mv *OfficeAuditLogCollector* /usr/local/bin/OfficeAuditLogCollector && \
+  chmod +x /usr/local/bin/OfficeAuditLogCollector && \
+  chmod +x /entrypoint.sh && \
+  chown -R 1001:1001 /app /entrypoint.sh /usr/local/bin/OfficeAuditLogCollector
+USER 1001
 ENTRYPOINT ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:stable-slim
+WORKDIR /app
+COPY Linux/* .
+COPY Docker/entrypoint.sh .
+RUN \
+  mv *OfficeAuditLogCollector* OfficeAuditLogCollector && \
+  chmod +x OfficeAuditLogCollector && \
+  chmod +x entrypoint.sh
+
+ENTRYPOINT ["bash", "-c", "/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:stable-slim
+COPY Docker/entrypoint.sh /
 WORKDIR /app
 COPY Linux/* .
-COPY Docker/entrypoint.sh .
 RUN \
   mv *OfficeAuditLogCollector* OfficeAuditLogCollector && \
   chmod +x OfficeAuditLogCollector && \
-  chmod +x entrypoint.sh
+  chmod +x /entrypoint.sh
 
-ENTRYPOINT ["/bin/bash", "-c", "/app/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ COPY Docker/entrypoint.sh /
 WORKDIR /app
 COPY Linux/* .
 RUN \
-  mv *OfficeAuditLogCollector* OfficeAuditLogCollector && \
-  chmod +x OfficeAuditLogCollector && \
+  mv *OfficeAuditLogCollector* /OfficeAuditLogCollector && \
+  chmod +x /OfficeAuditLogCollector && \
   chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ To run the command-line executable use the following syntax:
 
 OfficeAuditLogCollector(.exe) %tenant_id% %client_key% %secret_key% --config %path/to/config.yaml%
 
+To run the Docker Image use the following syntax:
+```bash
+docker run \
+   -e TENANT_ID=***REMOVED*** \
+   -e CLIENT_KEY=***REMOVED*** \ 
+   -e SECRET_KEY=***REMOVED*** \
+   -v ${PWD}/ConfigExamples/fluentd.yaml:/app/config.yaml oac
+```
 To create a config file you can start with the 'fullConfig.yaml' from the ConfigExamples folder. This has all the 
 possible options and some explanatory comments. Cross-reference with a config example using the output(s) of your choice, and you
 should be set.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ docker run \
    -e TENANT_ID=***REMOVED*** \
    -e CLIENT_KEY=***REMOVED*** \ 
    -e SECRET_KEY=***REMOVED*** \
-   -v ${PWD}/ConfigExamples/fluentd.yaml:/app/config.yaml oac
+   -v ${PWD}/ConfigExamples/fluentd.yaml:/app/config.yaml \
+   ghcr.io/ddbnl/office365-audit-log-collector:latest 
 ```
 To create a config file you can start with the 'fullConfig.yaml' from the ConfigExamples folder. This has all the 
 possible options and some explanatory comments. Cross-reference with a config example using the output(s) of your choice, and you

--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ OfficeAuditLogCollector(.exe) %tenant_id% %client_key% %secret_key% --config %pa
 To run the Docker Image use the following syntax:
 ```bash
 docker run \
-   -e TENANT_ID=***REMOVED*** \
-   -e CLIENT_KEY=***REMOVED*** \ 
-   -e SECRET_KEY=***REMOVED*** \
+   -e TENANT_ID=<Tenant-ID> \
+   -e CLIENT_KEY=<Client-ID> \ 
+   -e SECRET_KEY=<Secret> \
    -v ${PWD}/ConfigExamples/fluentd.yaml:/app/config.yaml \
    ghcr.io/ddbnl/office365-audit-log-collector:latest 
 ```


### PR DESCRIPTION
Currently, only Binaries are Provided.

For an Easy Deployment on NAS or Kubernetes Systems Docker is needed.

This implementation just grabs the binary from the repo, if the structure will change in the future, the dockerfile also has to be changed.